### PR TITLE
#151980451 Make API endpoints RESTful

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -95,3 +95,4 @@ practicalmeteor:sinon
 
 
 # Custom Packages
+simple:rest

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -148,6 +148,8 @@ service-configuration@1.0.11
 session@1.1.7
 sha@1.0.9
 shell-server@0.2.1
+simple:json-routes@2.1.0
+simple:rest@1.1.1
 spacebars@1.0.13
 spacebars-compiler@1.0.13
 srp@1.0.10


### PR DESCRIPTION
#### What does this PR do?
Extends Meteor DDP methods by making RESTful API endpoints corresponding to the methods and publications.
#### Description of Task to be completed?
- Add the simple:rest meteor package
#### How should this be manually tested?
Start the app locally or get the hosted URL, make a `GET` request to `/publications/api-routes`.  You should then get a response listing all the endpoints currently available for consumption over HTTP/HTTPS.
#### Any background context you want to provide?
Extending Meteor DDP methods and providing restful API would make it easier to:
- Build a mobile app that would consume your Meteor app's data
- Expose an API for other people to get data
- Integrate with other frameworks and platforms without having to integrate a DDP client
#### What are the relevant pivotal tracker stories?
Story #151980451: Make API endpoints RESTful
#### Screenshots (if appropriate)
<img width="1137" alt="screen shot 2017-10-25 at 7 13 38 pm" src="https://user-images.githubusercontent.com/20444781/32019011-ab5a3fae-b9c3-11e7-86af-8300bb6b4f28.png">

