### PR TITLE
feature(search): Real time search

### DIFF
--- a/imports/plugins/included/search-mongo/server/publications/searchresults.js
+++ b/imports/plugins/included/search-mongo/server/publications/searchresults.js
@@ -9,8 +9,13 @@ const supportedCollections = ["products", "orders", "accounts"];
 function getProductFindTerm(searchTerm, searchTags, userId) {
   const shopId = Reaction.getShopId();
   const findTerm = {
-    shopId: shopId,
-    $text: {$search: searchTerm}
+    $and: [
+      { shopId: shopId },
+      {title: {
+        $regex: searchTerm,
+        $options: "i"
+      } }
+    ]
   };
   if (searchTags.length) {
     findTerm.hashtags = {$all: searchTags};
@@ -125,6 +130,9 @@ Meteor.publish("SearchResults", function (collection, searchTerm, facets, maxRes
   check(facets, Match.OneOf(Array, undefined));
   Logger.debug(`Returning search results on ${collection}. SearchTerm: |${searchTerm}|. Facets: |${facets}|.`);
   if (!searchTerm) {
+    return this.ready();
+  }
+  if (collection === "products" && searchTerm.length < 3) {
     return this.ready();
   }
   return getResults[collection](searchTerm, facets, maxResults, this.userId);


### PR DESCRIPTION
#### What does this PR do?
Similar to a google search, display relevant results on the page as a user is typing rather than wait until they submit the search.
#### Description of Task to be completed?
- Search with pattern match
- Start search on third keystroke
#### How should this be manually tested?
When user clicks the search icon and starts typing on the input that appears, they should start seeing search results as they type.
#### Any background context you want to provide?
For latency sake, search should only start on the third keystroke.
#### What are the relevant pivotal tracker stories?
Finishes #151980455
#### Screenshots (if appropriate)
<img width="1438" alt="screen shot 2017-10-30 at 4 55 00 pm" src="https://user-images.githubusercontent.com/20444781/32180811-3f0030f6-bd93-11e7-8bf0-11641d1eb82b.png">
