### PR TITLE
feat(notification):  I should be able to receive email Notifications and sms alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "moment": "^2.15.1",
     "moment-timezone": "^0.5.5",
     "money": "^0.2.0",
+    "nexmo": "^2.0.2",
     "node-geocoder": "^3.15.0",
     "nodemailer": "^2.6.4",
     "nodemailer-wellknown": "^0.2.0",


### PR DESCRIPTION
#### What does this PR do?
It adds email and sms notifications to the app. This ensures the user is always kept informed of his transaction with theoden-rc.
#### Description of Task to be completed?
When a user places an order, the user is notified through his email, that he placed an order with theoden-rc and he is also sent an SMS to notify him of his placed order. Also when the order has been shipped by the admin, the user is notified again. When the user cancels a placed order, the user is also notified of the cancelled order process using both email and sms.
#### Any background context you want to provide?
nil
#### What are the relevant pivotal tracker stories?
#### Screenshots (if appropriate)
![email notification for order placed](https://user-images.githubusercontent.com/13855608/32546101-3bec64ec-c47e-11e7-93af-32b123f2d887.jpg)
![screenshot_20171107-111539](https://user-images.githubusercontent.com/13855608/32546359-1ecbcc76-c47f-11e7-923e-25474f07623e.png)

#### Questions:
nil

