### PR TITLE
#152682337 Change shipment status for canceled orders

### DIFF
--- a/imports/plugins/core/orders/client/templates/list/ordersList.html
+++ b/imports/plugins/core/orders/client/templates/list/ordersList.html
@@ -23,7 +23,7 @@
           <span data-i18n="order.completed">Completed</span>
           {{else}} {{#if orderCancelled}}
 
-          <span data-i18n="order.canceled">Cancelled</span>
+          <span data-i18n="order.filter.canceled">Cancelled</span>
           {{else}}
           <span data-i18n="order.processing">Processing</span>
           {{/if}} {{/if}}

--- a/imports/plugins/core/orders/client/templates/orders.js
+++ b/imports/plugins/core/orders/client/templates/orders.js
@@ -309,6 +309,14 @@ Template.orderStatusDetail.helpers({
 
   shipmentStatus() {
     const self = this;
+    if (this.workflow.status === "canceled" ||
+      this.workflow.status === "refunded") {
+      return {
+        shipped: false,
+        status: "danger",
+        label: i18next.t("order.filter.canceled")
+      };
+    }
     const shipment = this.shipping[0];
     const shipped = _.every(shipment.items, (shipmentItem) => {
       for (const fullItem of self.items) {

--- a/imports/plugins/core/orders/client/templates/workflow/shippingSummary.js
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingSummary.js
@@ -78,6 +78,15 @@ Template.coreOrderShippingSummary.helpers({
   },
   shipmentStatus() {
     const order = Template.instance().order;
+
+    if (order.workflow.status === "canceled" ||
+      order.workflow.status === "refunded") {
+      return {
+        shipped: false,
+        status: "danger",
+        label: i18next.t("order.filter.canceled")
+      };
+    }
     const shipment = Template.instance().order.shipping[0];
     const shipped = _.every(shipment.items, (shipmentItem) => {
       for (const fullItem of order.items) {


### PR DESCRIPTION
#### What does this PR do?

- Fixes an issue where canceled orders don't appear as canceled

#### How should this be manually tested?

- Make an order, cancel the order
- login as admin and view order status

#### What are the relevant pivotal tracker stories?

https://www.pivotaltracker.com/story/show/152746661

#### Screenshots (if appropriate)
<img width="894" alt="screen shot 2017-11-10 at 9 58 25 am" src="https://user-images.githubusercontent.com/11561738/32650562-8eb23798-c5fe-11e7-8682-d6ae9fb5a287.png">
